### PR TITLE
Add UBX-INF-* logging messages

### DIFF
--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1662,6 +1662,8 @@ class NavPvt extends Message:
   */
   static MAX-PROTVER/string := ""
 
+  static DEGREES-SCALING-FACTOR_ ::= 1e7
+
   /** Unknown GNSS fix. */
   static NO-FIX ::= 0
   /** Dead reckoning only. */
@@ -1783,8 +1785,13 @@ class NavPvt extends Message:
 
   /** Convenience method for $lon. */
   // To match message type 'UBX-NAV-POSLLH'.
-  longitude -> int:
+  longitude-raw -> int:
     return lon
+
+  /** Convenience method for $lon converted to degrees (as float). */
+  // To match message type 'UBX-NAV-POSLLH'.
+  longitude-deg -> float:
+    return lon / DEGREES-SCALING-FACTOR_
 
   /** Latitude. */
   lat -> int:
@@ -1792,8 +1799,13 @@ class NavPvt extends Message:
 
   /** Convenience method for $lat. */
   // To match message type 'UBX-NAV-POSLLH'.
-  latitude -> int:
+  latitude-raw -> int:
     return lat
+
+  /** Convenience method for $lat converted to degrees (as float). */
+  // To match message type 'UBX-NAV-POSLLH'.
+  latitude-deg -> float:
+    return lat / DEGREES-SCALING-FACTOR_
 
   /** Height above ellipsoid in millimeter. */
   height -> int:
@@ -1878,8 +1890,7 @@ class NavPvt extends Message:
     return uint16_ 90
 
   stringify -> string:
-    return  "$super: latitude:$(latitude)|longitude:$(longitude)"
-
+    return  "$super: latitude:$(latitude-deg)|longitude:$(longitude-deg)"
 
 /**
 The UBX-NAV-SOL message.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2751,10 +2751,11 @@ class CfgInf extends Message:
   /**
   Construct a blank instance of UBX-CFG-INF.
 
-  Warning: If sent, configurations present in this message would overwrite the
-    current configuration, not edit it.  To edit the current configuration,
-    poll for this message, and use the methods in the response message.  Then
-    send that message back as a configuration message.
+  # Warning
+  Configurations present in this message overwrite the current configuration,
+    not edit it.  To edit the current configuration, poll for this message, and
+    use the methods in the response message.  Then send that message back as a
+    configuration message.
   */
   constructor --protocol-id/int=PROTO-UBX:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -915,9 +915,6 @@ class CfgPrt extends Message:
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
-  id-string_ -> string:
-    return "PRT"
-
   /**
   Ublox internal port ID.
 
@@ -992,9 +989,6 @@ class CfgRst extends Message:
     put-uint8_ 2 reset-mode
     put-uint8_ 3 Message.RESERVED_
 
-  id-string_ -> string:
-    return "RST"
-
 /**
 The UBX-NAV-STATUS message.
 
@@ -1039,9 +1033,6 @@ class NavStatus extends Message:
   /** Constructs a UBX-NAV-STATUS message from raw byte array. */
   constructor.private_ payload:
     super.private_ Message.NAV ID payload
-
-  id-string_ -> string:
-    return "STATUS"
 
   /** The GPS interval time of week of the navigation epoch. */
   itow -> int:
@@ -1131,9 +1122,6 @@ class NavSat extends Message:
 
   constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
-
-  id-string_ -> string:
-    return "SAT"
 
   /** The GPS interval time of week of the navigation epoch. */
   itow -> int:
@@ -1423,10 +1411,6 @@ class MonVer extends Message:
   constructor.private_ payload/ByteArray:
     super.private_ Message.MON ID payload
 
-  /** See $super. */
-  id-string_ -> string:
-    return "VER"
-
   /** Software version string. */
   // Null terminated with fixed field size of 30 bytes.
   sw-version -> string:
@@ -1510,9 +1494,6 @@ class NavPosLlh extends Message:
   constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
 
-  id-string_ -> string:
-    return "POSLLH"
-
   /** GPS time of week of the navigation epoch. */
   itow -> int:
     return uint32_ 0
@@ -1579,9 +1560,6 @@ class NavSvInfo extends Message:
 
   constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
-
-  id-string_ -> string:
-    return "SVINFO"
 
   /** The GPS interval time of week of the navigation epoch. (ms). */
   itow -> int:
@@ -1667,9 +1645,6 @@ class NavPvt extends Message:
 
   constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
-
-  id-string_ -> string:
-    return "PVT"
 
   /** Whether this is a GNSS fix. */
   is-gnss-fix -> bool:
@@ -1906,9 +1881,6 @@ class NavSol extends Message:
   constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
 
-  id-string_ -> string:
-    return "SOL"
-
   /** Whether this is a GNSS fix. */
   is-gnss-fix -> bool:
     return (flags & FLAGS-GPS-FIX-OK_) != 0
@@ -2051,8 +2023,6 @@ class NavTimeUtc extends Message:
 
   constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
-
-  id-string_ -> string: return "TIMEUTC"
 
   /** The GPS interval time of week of the navigation epoch. */
   itow -> int:
@@ -2266,9 +2236,6 @@ class CfgTp5 extends Message:
     if use-utc: flags |= FLAG-UTC-GRID
     put-uint32_ 28 flags
 
-  id-string_ -> string:
-    return "TP5"
-
   /**
   Time pulse selection.
 
@@ -2470,10 +2437,6 @@ class CfgNav5 extends Message:
 
     put-uint16_ 0 mask
 
-
-  id-string_ -> string:
-    return "NAV5"
-
   dyn-model -> int:
     return uint8_ 2
 
@@ -2578,9 +2541,6 @@ class CfgGnss extends Message:
       put-uint8_ (base + BLOCK-MAXTRKCH_) block["maxTrkCh"]
       put-uint8_ (base + BLOCK-RESERVED1_) 0
       put-uint32_ (base + BLOCK-FLAGS_) block["flags"]
-
-  id-string_ -> string:
-    return "GNSS"
 
   /**
   Convenience builder for a configuration block.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -741,7 +741,7 @@ class CfgMsg extends Message:
 
   /** Returns the string name of the given port. */
   port-string_ port/int -> string:
-    assert: -1 <= port <= 5
+    assert: port == PORT-ALL or 0 <= port <= 5
     return PACK-PORT-TYPES[port]
 
   /**
@@ -762,7 +762,7 @@ class CfgMsg extends Message:
   */
   set-rate port/int=PORT-ALL --rate/int:
     assert: payload.size == 8
-    assert: -1 <= port <= 5
+    assert: port == PORT-ALL or 0 <= port <= 5
     assert: 0 <= rate <= 0xFF
 
     // if $enable is null, replace instead of adjusting the existing value.
@@ -2786,7 +2786,7 @@ class CfgInf extends Message:
   */
   set-port-type --port/int=PORT-ALL --type/int --enable/bool?=true:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA
-    assert: -1 <= port <= 5
+    assert: port == PORT-ALL or 0 <= port <= 5
     assert: 0 <= type <= 0xFF
 
     // if $enable is null, the value is replaced, instead of adjusting bits in
@@ -2820,7 +2820,7 @@ class CfgInf extends Message:
   */
   set-port-type-mask port/int --mask/int -> none:
     assert: payload.size >= 10
-    assert: -1 <= port <= 5
+    assert: port == PORT-ALL or 0 <= port <= 5
     set-port-type --port=port --enable=null --type=mask
 
   // Convenience per-port getters/setters.
@@ -2881,7 +2881,7 @@ class CfgInf extends Message:
 
   /** Returns the string name of the given port. */
   port-string_ port/int -> string:
-    assert: -1 <= port <= 5
+    assert: port == PORT-ALL or 0 <= port <= 5
     return PACK-PORT-TYPES[port]
 
   /** See $super. */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -735,7 +735,7 @@ class CfgMsg extends Message:
   message-id -> int:
     return uint8_ 1
 
-  /** True if this is a poll message (2-byte payload). */
+  /** Whether this is a poll message (2-byte payload). */
   is-poll -> bool:
     return payload.size == 2
 
@@ -2769,7 +2769,7 @@ class CfgInf extends Message:
   constructor.private_ bytes/ByteArray:
     super.private_ Message.CFG ID bytes
 
-  /** True if this is a poll message (1-byte payload). */
+  /** Whether this is a poll message (1-byte payload). */
   is-poll -> bool:
     return payload.size == 1
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -727,7 +727,7 @@ class CfgMsg extends Message:
     put-uint8_ 1 msg-id
     set-rate port --rate=rate
 
-  /** Constructs a message to retireve the current rate for $msg-class and $msg-id. */
+  /** Constructs a message to retrieve the current rate for $msg-class and $msg-id. */
   constructor.poll --msg-class --msg-id:
     super.private_ Message.CFG ID #[msg-class, msg-id]
 
@@ -779,7 +779,7 @@ class CfgMsg extends Message:
     assert: 0 <= rate <= 0xFF
 
     if port == PORT-ALL:
-      // Deliberately misses port PORT-RES5, as stipluated in the manual.
+      // Deliberately misses port PORT-RES5, as stipulated in the manual.
       5.repeat:
         put-uint8_ (2 + it) rate
     else:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2930,10 +2930,8 @@ class InfError extends Message:
 
   /** See $super. */
   stringify -> string:
-    if payload.size > 0:
-      return "$super: $text"
-    else:
-      return super
+    if payload.size > 0: return "$super: $text"
+    return super
 
 /**
 The UBX-INF-WARNING message.
@@ -2973,10 +2971,8 @@ class InfWarning extends Message:
 
   /** See $super. */
   stringify -> string:
-    if payload.size > 0:
-      return "$super: $text"
-    else:
-      return super
+    if payload.size > 0: return "$super: $text"
+    return super
 
 /**
 The UBX-INF-NOTICE message.
@@ -3016,10 +3012,8 @@ class InfNotice extends Message:
 
   /** See $super. */
   stringify -> string:
-    if payload.size > 0:
-      return "$super: $text"
-    else:
-      return super
+    if payload.size > 0: return "$super: $text"
+    return super
 
 /**
 The UBX-INF-TEST message.
@@ -3059,10 +3053,8 @@ class InfTest extends Message:
 
   /** See $super. */
   stringify -> string:
-    if payload.size > 0:
-      return "$super: $text"
-    else:
-      return super
+    if payload.size > 0: return "$super: $text"
+    return super
 
 /**
 The UBX-INF-DEBUG message.
@@ -3102,7 +3094,5 @@ class InfDebug extends Message:
 
   /** See $super. */
   stringify -> string:
-    if payload.size > 0:
-      return "$super: $text"
-    else:
-      return super
+    if payload.size > 0: return "$super: $text"
+    return super

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1436,7 +1436,7 @@ class MonVer extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Construct a poll-request UBX-MON-VER. */
+  /** Constructs a poll-request UBX-MON-VER. */
   constructor.poll:
     super.private_ Message.MON ID #[]
 
@@ -2749,7 +2749,7 @@ class CfgInf extends Message:
     super.private_ Message.CFG ID #[protocol-id]
 
   /**
-  Construct a blank instance of UBX-CFG-INF.
+  Constructs a blank instance of UBX-CFG-INF.
 
   # Warning
   Configurations present in this message overwrite the current configuration,

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1062,7 +1062,7 @@ class NavStatus extends Message:
   fix-type -> int:
     return uint8_ 4
 
-  // Deprecated - switched to use naming convention from later message type.
+  // Deprecated - use $fix-type.
   gps-fix -> int: return fix-type
 
   /**

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -567,7 +567,7 @@ class Message:
     end := start + length
     pos := payload.index-of '\0' --from=start --to=end
     if pos > -1: end = pos
-    return (payload[start..end]).to-string
+    return payload[start..end].to-string
 
 /**
 The UBX-ACK-ACK message.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -580,7 +580,7 @@ class AckAck extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.ACK ID payload
 
@@ -628,9 +628,9 @@ class AckNak extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ bytearray/ByteArray:
-    super.private_ Message.ACK ID bytearray
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
+  constructor.private_ payload/ByteArray:
+    super.private_ Message.ACK ID payload
 
   /** The class ID of the original message being NAK'ed. */
   class-id -> int:
@@ -726,7 +726,7 @@ class CfgMsg extends Message:
     assert: rates.size == 6
     super.private_ Message.CFG ID (#[msg-class, msg-id] + rates)
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2263,7 +2263,7 @@ class CfgTp5 extends Message:
     put-uint8_ 0 tp-idx
     put-uint8_ 1 1  // Version.
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2419,7 +2419,7 @@ class CfgNav5 extends Message:
   constructor.poll:
     super.private_ Message.CFG ID #[]
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2586,7 +2586,7 @@ class CfgGnss extends Message:
     // Empty payload poll (some firmwares accept either empty or msgVer=0).
     super.private_ Message.CFG ID #[]
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2760,7 +2760,7 @@ class CfgInf extends Message:
     super.private_ Message.CFG ID (ByteArray 10)
     put-uint8_ 0 protocol-id
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2916,7 +2916,7 @@ class InfError extends Message:
   */
   static MAX-PROTVER/string := ""
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -2959,7 +2959,7 @@ class InfWarning extends Message:
   */
   static MAX-PROTVER/string := ""
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -3002,7 +3002,7 @@ class InfNotice extends Message:
   */
   static MAX-PROTVER/string := ""
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -3045,7 +3045,7 @@ class InfTest extends Message:
   */
   static MAX-PROTVER/string := ""
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -3088,7 +3088,7 @@ class InfDebug extends Message:
   */
   static MAX-PROTVER/string := ""
 
- /** Constructs an instance with the $payload bytes from a retrieved message. */
+  /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -580,7 +580,7 @@ class AckAck extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.ACK ID payload
 
@@ -628,7 +628,7 @@ class AckNak extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ bytearray/ByteArray:
     super.private_ Message.ACK ID bytearray
 
@@ -726,7 +726,7 @@ class CfgMsg extends Message:
     assert: rates.size == 6
     super.private_ Message.CFG ID (#[msg-class, msg-id] + rates)
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2263,7 +2263,7 @@ class CfgTp5 extends Message:
     put-uint8_ 0 tp-idx
     put-uint8_ 1 1  // Version.
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2419,7 +2419,7 @@ class CfgNav5 extends Message:
   constructor.poll:
     super.private_ Message.CFG ID #[]
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2586,7 +2586,7 @@ class CfgGnss extends Message:
     // Empty payload poll (some firmwares accept either empty or msgVer=0).
     super.private_ Message.CFG ID #[]
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2760,7 +2760,7 @@ class CfgInf extends Message:
     super.private_ Message.CFG ID (ByteArray 10)
     put-uint8_ 0 protocol-id
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.CFG ID payload
 
@@ -2916,7 +2916,7 @@ class InfError extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -2959,7 +2959,7 @@ class InfWarning extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -3002,7 +3002,7 @@ class InfNotice extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -3045,7 +3045,7 @@ class InfTest extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 
@@ -3088,7 +3088,7 @@ class InfDebug extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Construct an instance with bytes from a retrieved message. */
+ /** Constructs an instance with the $payload bytes from a retrieved message. */
   constructor.private_ payload/ByteArray:
     super.private_ Message.INF ID payload
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -378,6 +378,8 @@ class Message:
         return CfgGnss.private_ payload
       if id == CfgInf.ID:
         return CfgInf.private_ payload
+      if id == CfgMsg.ID:
+        return CfgMsg.private_ payload
 
     if cls == Message.INF:
       if id == InfError.ID:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -778,8 +778,9 @@ class CfgMsg extends Message:
     assert: port == PORT-ALL or 0 <= port <= 5
     assert: 0 <= rate <= 0xFF
 
-    if port == PORT-ALL:  //
-      6.repeat:
+    if port == PORT-ALL:
+      // Deliberately misses port PORT-RES5, as stipluated in the manual.
+      5.repeat:
         put-uint8_ (2 + it) rate
     else:
       put-uint8_ (2 + port) rate
@@ -802,9 +803,10 @@ class CfgMsg extends Message:
   /** See $super. */
   stringify -> string:
     out-str := "$super"
+    info-str := "{0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)($(id-string_ class-id message-id))}"
     if is-poll:
-      return "$out-str: {poll}"
-    out-str += ": {0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)($(id-string_ class-id message-id))}"
+      return "$out-str: (poll) $info-str"
+    out-str += ": $info-str"
     out-set := []
     6.repeat:
       out-set.add "$(port-string_ (it))=0x$(%02x payload[2 + it])"

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -668,11 +668,11 @@ class CfgMsg extends Message:
   static PACK-PORT-TYPES := {
     PORT-ALL: "ALL",
     PORT-DDC: "DDC",
-    PORT-UART1:"UART1",
-    PORT-UART2:"UART2",
-    PORT-USB:"USB",
-    PORT-SPI:"SPI",
-    PORT-RES5:"RES5",
+    PORT-UART1: "UART1",
+    PORT-UART2: "UART2",
+    PORT-USB: "USB",
+    PORT-SPI: "SPI",
+    PORT-RES5: "RES5",
   }
 
   /**
@@ -842,12 +842,12 @@ class CfgPrt extends Message:
 
   static PACK-PORT-TYPES := {
     PORT-ALL: "ALL",
-    PORT-DDC:  "DDC",
-    PORT-UART1:"UART1",
-    PORT-UART2:"UART2",
-    PORT-USB:"USB",
-    PORT-SPI:"SPI",
-    PORT-RES5:"RES5",
+    PORT-DDC: "DDC",
+    PORT-UART1: "UART1",
+    PORT-UART2: "UART2",
+    PORT-USB: "USB",
+    PORT-SPI: "SPI",
+    PORT-RES5: "RES5",
   }
 
   // Todo: expose these on the constructor.
@@ -1026,6 +1026,16 @@ class NavStatus extends Message:
   /** Time only fix. */
   static TIME-ONLY ::= 5
 
+  /** Fix Types for Lookup*/
+  static PACK-FIX-TYPE_ ::= {
+    NO-FIX: "NO-FIX",
+    DEAD-RECKONING-ONLY: "DEAD-RECKONING-ONLY",
+    FIX-2D: "FIX-2D",
+    FIX-3D: "FIX-3D",
+    GPS-DEAD-FIX: "GPS-DEAD-FIX",
+    TIME-ONLY: "TIME-ONLY",
+  }
+
   /** Constructs a message to poll for a UBX-NAV-STATUS message. */
   constructor.poll:
     super.private_ Message.NAV ID #[]
@@ -1043,8 +1053,21 @@ class NavStatus extends Message:
 
   One of $NO-FIX, $DEAD-RECKONING-ONLY, $FIX-2D, $FIX-3D, $GPS-DEAD-FIX, $TIME-ONLY.
   */
-  gps-fix -> int:
+  fix-type -> int:
     return uint8_ 4
+
+  // Deprecated - switched to use naming convention from later message type.
+  gps-fix -> int: return fix-type
+
+  /**
+  The current fix type in string form.
+
+  One of "NO-FIX", "DEAD-RECKONING-ONLY", "FIX-2D", "FIX-3D", "GPS-DEAD-FIX",
+    "TIME-ONLY", or "UNKNOWN" in case of error or unexpected output.
+  */
+  fix-type-text fixtype=fix-type -> string:
+    return PACK-FIX-TYPE_.get fixtype --if-absent=:
+      return "UNKNOWN"
 
   /**
   Navigation status flags.
@@ -1874,6 +1897,16 @@ class NavSol extends Message:
   /** Time only fix. */
   static TIME-ONLY ::= 5
 
+  /** Fix Types for Lookup*/
+  static PACK-FIX-TYPE_ ::= {
+    NO-FIX: "NO-FIX",
+    DEAD-RECKONING-ONLY: "DEAD-RECKONING-ONLY",
+    FIX-2D: "FIX-2D",
+    FIX-3D: "FIX-3D",
+    GPS-DEAD-FIX: "GPS-DEAD-FIX",
+    TIME-ONLY: "TIME-ONLY",
+  }
+
   /** Constructs a poll UBX-NAV-SOL message. */
   constructor.poll:
     super.private_ Message.NAV ID #[]
@@ -1937,6 +1970,16 @@ class NavSol extends Message:
   */
   fix-type -> int:
     return uint8_ 10
+
+  /**
+  The current fix type in string form.
+
+  One of "NO-FIX", "DEAD-RECKONING-ONLY", "FIX-2D", "FIX-3D", "GPS-DEAD-FIX",
+    "TIME-ONLY", or "UNKNOWN" in case of error or unexpected output.
+  */
+  fix-type-text fixtype=fix-type -> string:
+    return PACK-FIX-TYPE_.get fixtype --if-absent=:
+      return "UNKNOWN"
 
   /**
   Fix status flags.
@@ -2653,12 +2696,12 @@ class CfgInf extends Message:
 
   static PACK-PORT-TYPES := {
     PORT-ALL: "ALL",
-    PORT-DDC:  "DDC",
-    PORT-UART1:"UART1",
-    PORT-UART2:"UART2",
-    PORT-USB:"USB",
-    PORT-SPI:"SPI",
-    PORT-RES5:"RES5",
+    PORT-DDC: "DDC",
+    PORT-UART1: "UART1",
+    PORT-UART2: "UART2",
+    PORT-USB: "USB",
+    PORT-SPI: "SPI",
+    PORT-RES5: "RES5",
   }
 
   /**

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -3002,7 +3002,7 @@ class InfWarning extends Message:
 /**
 The UBX-INF-NOTICE message.
 
-Asynchronous human-readable text message, emitted by the receiver for ublox-
+Asynchronous human-readable text message emitted by the receiver for ublox-
   sourced notice output (if configured).
 
 This message is not pollable.  It is enabled/disabled via configuration using
@@ -3043,7 +3043,7 @@ class InfNotice extends Message:
 /**
 The UBX-INF-TEST message.
 
-Asynchronous human-readable text message, emitted by the receiver (if
+Asynchronous human-readable text message emitted by the receiver (if
   configured) for ublox-sourced test output.
 
 This message is not pollable.  It is enabled/disabled via configuration using
@@ -3084,7 +3084,7 @@ class InfTest extends Message:
 /**
 The UBX-INF-DEBUG message.
 
-Asynchronous human-readable text message, emitted by the receiver (if
+Asynchronous human-readable text message emitted by the receiver (if
   configured) for ublox-sourced debug output.
 
 This message is not pollable.  It is enabled/disabled via configuration using

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -576,23 +576,23 @@ class AckAck extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
-  /** Constructs a dummy acknowledge message. */
+  /** Construct an instance with bytes from a retrieved message. */
   constructor.private_ payload:
     super.private_ Message.ACK ID payload
 
-  /** The class ID of the acknowledged message. */
+  /** The class ID of the original message being ACK'ed. */
   class-id -> int:
     return uint8_ 0
 
-  /** The class ID (converted to text) of the acknowledged message. */
+  /** The class ID (converted to text) of the ACK'ed message. */
   class-id-text -> string:
     return cls-string_ class-id
 
-  /** The message ID of the acknowledged message. */
+  /** The message ID of the original message being ACK'ed. */
   message-id -> int:
     return uint8_ 1
 
-  /** The message ID (converted to text, if known) of the acknowledged message. */
+  /** The message ID (converted to text, if known) of the ACK'ed message. */
   message-id-text -> string:
     return id-string_ class-id message-id
 
@@ -624,22 +624,23 @@ class AckNak extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
+  /** Construct an instance with bytes from a retrieved message. */
   constructor.private_ bytearray/ByteArray:
     super.private_ Message.ACK ID bytearray
 
-  /** The class ID of the NAK message. */
+  /** The class ID of the original message being NAK'ed. */
   class-id -> int:
     return uint8_ 0
 
-  /** The class ID (converted to text) of the NAK message. */
+  /** The class ID (converted to text) of the NAK'ed message. */
   class-id-text -> string:
     return cls-string_ class-id
 
-  /** The message ID of the NAK message. */
+  /** The message ID of the original message being NAK'ed. */
   message-id -> int:
     return uint8_ 1
 
-  /** The message ID (converted to text, if known) of the NAK message. */
+  /** The message ID (converted to text, if known) of the NAK'ed message. */
   message-id-text -> string:
     return id-string_ class-id message-id
 
@@ -714,8 +715,10 @@ class CfgMsg extends Message:
   constructor.poll --msg-class --msg-id:
     super.private_ Message.CFG ID #[msg-class, msg-id]
 
-  /** Set all port rates at once using 6*byte $rates byte array. */
-  constructor.per-port --msg-class --msg-id --rates/ByteArray:
+  /** Set all port rates at once using 6*byte byte array ($rates). */
+  constructor.per-port --msg-class/int --msg-id/int --rates/ByteArray:
+    assert: 0 <= msg-class <= 255
+    assert: 0 <= msg-id <= 255
     assert: rates.size == 6
     super.private_ Message.CFG ID (#[msg-class, msg-id] + rates)
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2784,7 +2784,7 @@ class CfgInf extends Message:
 
   Sets the type for all ports if $port is omitted. Use --enable or --no-enable to set.
   */
-  set-port-type --port/int=-1 --type/int --enable/bool?=true:
+  set-port-type --port/int=PORT-ALL --type/int --enable/bool?=true:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA
     assert: -1 <= port <= 5
     assert: 0 <= type <= 0xFF
@@ -2856,7 +2856,7 @@ class CfgInf extends Message:
 
   Sets the type for all ports if $port is omitted.
   */
-  enable-all --port/int=-1:
+  enable-all --port/int=PORT-ALL:
     set-port-type --port=port --enable=null --type=MASK-ALL
 
   // Helpers for disabling a given INF type on a port.
@@ -2870,7 +2870,7 @@ class CfgInf extends Message:
 
   Sets the type for all ports if $port is omitted.
   */
-  disable-all --port/int=-1:
+  disable-all --port/int=PORT-ALL:
     set-port-type --port=port --enable=null --type=MASK_NONE
 
   /** Returns the string name of this messages' protocol. */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -207,6 +207,10 @@ class Message:
       0x88: "SENIF",     // M8+.
       0x8D: "SLAS",      // M8+.
       0x93: "BATCH",     // M8+.
+
+      0x8A: "VALSET",    // M8/9+.
+      0x8B: "VALGET",    // M8/9+.
+      0x8C: "VALDEL",    // M8/9+.
     },
 
     // MON (0x0A).

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -332,7 +332,7 @@ class Message:
   payload/ByteArray
 
   /** Constructs a UBX message with the given $cls, $id, and $payload. */
-  constructor.private_ .cls .id .payload:
+  constructor.private_ .cls/int .id/int .payload/ByteArray:
 
   /**
   Constructs a UBX message with the given $cls, $id, and $payload.
@@ -340,7 +340,7 @@ class Message:
   If message is implemented in this package, then it returns the appropriate
     sub-class.
   */
-  constructor cls id payload:
+  constructor cls/int id/int payload:
     if cls == Message.ACK:
       if id == AckAck.ID:
         return AckAck.private_ payload
@@ -492,11 +492,11 @@ class Message:
       bytes[bytes.size - 1] = ck-b
     return bytes
 
-  cls-string_ clsid=cls -> string:
+  cls-string_ clsid/int=cls -> string:
     return PACK-CLASSES.get clsid --if-absent=:
       return "0x$(%02x clsid)"
 
-  id-string_ clsid=cls msgid=id -> string:
+  id-string_ clsid/int=cls msgid/int=id -> string:
     if Message.PACK-MESSAGE-TYPES.contains clsid and
         Message.PACK-MESSAGE-TYPES[clsid].contains msgid:
       return Message.PACK-MESSAGE-TYPES[clsid][msgid]
@@ -515,45 +515,45 @@ class Message:
     return payload.hash-code ^ ((cls << 16) | id)
 
   /** Helper to return an int8 from payload index. */
-  int8_ index --payload=payload -> int: return LITTLE-ENDIAN.int8 payload index
+  int8_ index/int --payload/ByteArray=payload -> int: return LITTLE-ENDIAN.int8 payload index
 
   /** Helper to return an uint8 from payload index. */
-  uint8_ index --payload=payload -> int: return payload[index]
+  uint8_ index/int --payload/ByteArray=payload -> int: return payload[index]
 
   /** Helper to return an int16 from payload index. */
-  int16_ index --payload=payload -> int: return LITTLE-ENDIAN.int16 payload index
+  int16_ index/int --payload/ByteArray=payload -> int: return LITTLE-ENDIAN.int16 payload index
 
   /** Helper to return an uint16 from payload index. */
-  uint16_ index --payload=payload -> int: return LITTLE-ENDIAN.uint16 payload index
+  uint16_ index/int --payload/ByteArray=payload -> int: return LITTLE-ENDIAN.uint16 payload index
 
   /** Helper to return an int32 from payload index. */
-  int32_ index --payload=payload -> int: return LITTLE-ENDIAN.int32 payload index
+  int32_ index/int --payload/ByteArray=payload -> int: return LITTLE-ENDIAN.int32 payload index
 
   /** Helper to return an uint32 from payload index. */
-  uint32_ index --payload=payload -> int: return LITTLE-ENDIAN.uint32 payload index
+  uint32_ index/int --payload/ByteArray=payload -> int: return LITTLE-ENDIAN.uint32 payload index
 
   /** Helper to insert an int8 into payload index. */
-  put-int8_ index value --payload=payload -> none:
+  put-int8_ index/int value/int --payload/ByteArray=payload -> none:
     LITTLE-ENDIAN.put-int8 payload index value
 
   /** Helper to insert an uint8 into payload index. */
-  put-uint8_ index value --payload=payload -> none:
+  put-uint8_ index/int value/int --payload/ByteArray=payload -> none:
     payload[index] = value
 
   /** Helper to insert an int16 into payload index. */
-  put-int16_ index value --payload=payload -> none:
+  put-int16_ index/int value/int --payload=payload -> none:
     LITTLE-ENDIAN.put-int16 payload index value
 
   /** Helper to insert an uint16 into payload index. */
-  put-uint16_ index value --payload=payload -> none:
+  put-uint16_ index/int value/int --payload=payload -> none:
     LITTLE-ENDIAN.put-uint16 payload index value
 
   /** Helper to insert an int32 into payload index. */
-  put-int32_ index value --payload=payload -> none:
+  put-int32_ index/int value/int --payload=payload -> none:
     LITTLE-ENDIAN.put-int32 payload index value
 
   /** Helper to insert an uint32 into payload index. */
-  put-uint32_ index value --payload=payload -> none:
+  put-uint32_ index/int value/int --payload=payload -> none:
     LITTLE-ENDIAN.put-uint32 payload index value
 
   /** Helper to read a '\0'-terminated string from the payload. */
@@ -590,7 +590,7 @@ class AckAck extends Message:
   static MAX-PROTVER/string := ""
 
   /** Constructs a dummy acknowledge message. */
-  constructor.private_ cls id:
+  constructor.private_ cls/int id:
     super.private_ Message.ACK ID #[cls, id]
 
   /** Constructs an instance with the payload $bytes from a retrieved message. */
@@ -638,7 +638,7 @@ class AckNak extends Message:
   static MAX-PROTVER/string := ""
 
   /** Constructs a dummy NAK message. */
-  constructor.private_ cls id:
+  constructor.private_ cls/int id/int:
     super.private_ Message.ACK ID #[cls, id]
 
   /** Constructs an instance with the payload $bytes from a retrieved message. */
@@ -728,7 +728,9 @@ class CfgMsg extends Message:
     set-rate port --rate=rate
 
   /** Constructs a message to retrieve the current rate for $msg-class and $msg-id. */
-  constructor.poll --msg-class --msg-id:
+  constructor.poll --msg-class/int --msg-id/int:
+    assert: 0 <= msg-class <= 255
+    assert: 0 <= msg-id <= 255
     super.private_ Message.CFG ID #[msg-class, msg-id]
 
   /** Set all port rates at once using byte array ($rates) with 6 entries. */
@@ -1004,7 +1006,7 @@ class CfgRst extends Message:
   The default parameters are a controlled software reset with a cold start.
   See the description for other parameter options.
   */
-  constructor --clear-sections=0xFFFF --reset-mode=2:
+  constructor --clear-sections/int=0xFFFF --reset-mode=2:
     super.private_ Message.CFG ID (ByteArray 4)
     put-uint16_ 0 clear-sections
     put-uint8_ 2 reset-mode
@@ -1642,7 +1644,7 @@ class NavSvInfo extends Message:
 
   The $index must satisfy 0 <= $index < $num-ch.
   */
-  satellite-data index -> SatelliteData:
+  satellite-data index/int -> SatelliteData:
     if not 0 <= index < num-ch: throw "INVALID ARGUMENT"
     return SatelliteData index payload --src-id=ID
 
@@ -2028,7 +2030,7 @@ class NavSol extends Message:
   One of "NO-FIX", "DEAD-RECKONING-ONLY", "FIX-2D", "FIX-3D", "GPS-DEAD-FIX",
     "TIME-ONLY", or "UNKNOWN" in case of error or unexpected output.
   */
-  fix-type-text fixtype=fix-type -> string:
+  fix-type-text fixtype/int=fix-type -> string:
     return PACK-FIX-TYPE_.get fixtype --if-absent=:
       return "UNKNOWN"
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -747,8 +747,8 @@ class CfgMsg extends Message:
   /**
   Gets the rate for the message type for the given $port.
 
-  $port must be one of $PORT-DDC(0), $PORT-UART1(1), $PORT-UART2(2),
-    $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
+  The $port parameter must be one of $PORT-DDC(0), $PORT-UART1(1),
+    $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
   */
   get-rate port/int -> int:
     assert: payload.size == 8
@@ -2803,8 +2803,8 @@ class CfgInf extends Message:
   /**
   Gets the mask byte for the given $port.
 
-  $port must be one of $PORT-DDC(0), $PORT-UART1(1), $PORT-UART2(2),
-    $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
+  The $port parameter must be one of $PORT-DDC(0), $PORT-UART1(1),
+    $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
   */
   get-port-type-mask port/int -> int:
     assert: payload.size >= 10

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -739,7 +739,7 @@ class CfgMsg extends Message:
   is-poll -> bool:
     return payload.size == 2
 
-  /** Return the string name of the given port. */
+  /** Returns the string name of the given port. */
   port-string_ port/int -> string:
     assert: -1 <= port <= 5
     return PACK-PORT-TYPES[port]
@@ -2872,13 +2872,13 @@ class CfgInf extends Message:
   disable-all --port/int=-1:
     set-port-type --port=port --enable=null --type=MASK_NONE
 
-  /** Return the string name of this messages' protocol. */
+  /** Returns the string name of this messages' protocol. */
   proto-string_ -> string:
     if protocol-id == PROTO-UBX: return "UBX"
     if protocol-id == PROTO-NMEA: return "NMEA"
     return "UNKNOWN($protocol-id)"
 
-  /** Return the string name of the given port. */
+  /** Returns the string name of the given port. */
   port-string_ port/int -> string:
     assert: -1 <= port <= 5
     return PACK-PORT-TYPES[port]

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2743,8 +2743,6 @@ class CfgInf extends Message:
     PORT-RES5: "RES5",
   }
 
-  static ENABLED ::= true
-  static DISABLED ::= false
   /**
   The minimum protocol version for the message type.
 
@@ -2829,7 +2827,7 @@ class CfgInf extends Message:
   $port must be one of  $PORT-ALL(-1), $PORT-DDC(0), $PORT-UART1(1),
     $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
   */
-  set-port-level-raw port/int=PORT-ALL --raw-value/int -> none:
+  set-port-level port/int=PORT-ALL --raw-value/int -> none:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA
     assert: port == PORT-ALL or 0 <= port <= 5
     assert: 0 <= raw-value <= 0x1F
@@ -2851,39 +2849,24 @@ class CfgInf extends Message:
   The $port parameter must be one of $PORT-DDC(0), $PORT-UART1(1),
     $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
   */
-  get-port-level-raw port/int -> int:
+  get-port-level port/int -> int:
     assert: payload.size >= 10
     assert: 0 <= port <= 5
     return uint8_ (4 + port)
 
-  // Convenience per-port getters/setters.
-  get-ddc-level-raw -> int: return get-port-level-raw PORT-DDC
-  get-uart1-level-raw -> int: return get-port-level-raw PORT-UART1
-  get-uart2-level-raw -> int: return get-port-level-raw PORT-UART2
-  get-usb-level-raw -> int: return get-port-level-raw PORT-USB
-  get-spi-level-raw -> int: return get-port-level-raw PORT-SPI
-  get-res5-level-raw -> int: return get-port-level-raw PORT-RES5
-
-  set-ddc-level-raw level/int -> none: set-port-level-raw PORT-DDC --raw-value=level
-  set-uart1-level-raw level/int -> none: set-port-level-raw PORT-UART1 --raw-value=level
-  set-uart2-level-raw level/int -> none: set-port-level-raw PORT-UART2 --raw-value=level
-  set-usb-level-raw level/int -> none: set-port-level-raw PORT-USB --raw-value=level
-  set-spi-level-raw level/int -> none: set-port-level-raw PORT-SPI --raw-value=level
-  set-res5-level-raw level/int -> none: set-port-level-raw PORT-RES5 --raw-value=level
-
   // Helpers for checking whether a given INF type is enabled on a port.
-  error-enabled port/int -> bool: return (get-port-level-raw port) & LEVEL-ERROR != 0
-  warning-enabled port/int -> bool: return (get-port-level-raw port) & LEVEL-WARNING != 0
-  notice-enabled port/int -> bool: return (get-port-level-raw port) & LEVEL-NOTICE != 0
-  test-enabled port/int -> bool: return (get-port-level-raw port) & LEVEL-TEST != 0
-  debug-enabled port/int -> bool: return (get-port-level-raw port) & LEVEL-DEBUG != 0
+  error-enabled port/int -> bool: return (get-port-level port) & LEVEL-ERROR != 0
+  warning-enabled port/int -> bool: return (get-port-level port) & LEVEL-WARNING != 0
+  notice-enabled port/int -> bool: return (get-port-level port) & LEVEL-NOTICE != 0
+  test-enabled port/int -> bool: return (get-port-level port) & LEVEL-TEST != 0
+  debug-enabled port/int -> bool: return (get-port-level port) & LEVEL-DEBUG != 0
 
   // Helpers for enabling a given INF type on a port.
-  enable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR ENABLED
-  enable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING ENABLED
-  enable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE ENABLED
-  enable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST ENABLED
-  enable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG ENABLED
+  enable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR true
+  enable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING true
+  enable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE true
+  enable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST true
+  enable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG true
   /**
   Enables all message types for the given $port.
 
@@ -2893,11 +2876,11 @@ class CfgInf extends Message:
     set-port-level port --level=LEVEL-ALL
 
   // Helpers for disabling a given INF type on a port.
-  disable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR DISABLED
-  disable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING DISABLED
-  disable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE DISABLED
-  disable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST DISABLED
-  disable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG DISABLED
+  disable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR false
+  disable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING false
+  disable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE false
+  disable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST false
+  disable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG false
   /**
   Disables all message types for the given $port.
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2800,8 +2800,8 @@ class CfgInf extends Message:
   Enable (or disable) a specific logging $level, for a specific $port.
 
   Adds or removes the given $level bit from the ports' bitmask.  This method
-    does not replace other bits that might be set.  Use $enable to set or unset
-    the desired bit.
+    does not replace other bits that might be set ($set-port-level replaces the
+    entire mask).  Use $enable to set or unset the desired bit.
 
   Sets the logging $level for all ports if $port is omitted. Logging $level
     should be one of  $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE, $LEVEL-TEST,
@@ -2825,9 +2825,9 @@ class CfgInf extends Message:
   Sets the raw logging level mask byte the given $port.
 
   $level is a bitmask of all the bits of the requested levels combined.
-    Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
+    (Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
     $LEVEL-TEST, and $LEVEL-DEBUG.  Setting one level will replace all other
-    bits.
+    bits.)
 
   $port must be one of  $PORT-ALL(-1), $PORT-DDC(0), $PORT-UART1(1),
     $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
@@ -2848,8 +2848,8 @@ class CfgInf extends Message:
   Gets the raw logging level mask byte the given $port.
 
   Output is a bitmask of all the bits of the requested levels combined.
-    Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
-    $LEVEL-TEST, and $LEVEL-DEBUG.
+    (Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
+    $LEVEL-TEST, and $LEVEL-DEBUG.)
 
   The $port parameter must be one of $PORT-DDC(0), $PORT-UART1(1),
     $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
@@ -2894,8 +2894,7 @@ class CfgInf extends Message:
 
   Sets the type for all ports if $port is omitted.
   */
-  enable-all --port/int=PORT-ALL:
-    set-port-level port LEVEL-ALL
+  enable-all --port/int=PORT-ALL -> none: set-port-level port LEVEL-ALL
 
   /**  Disables the $LEVEL-ERROR logging level on the given $port. */
   disable-error port/int=PORT-ALL -> none: enable-port-level port LEVEL-ERROR --enable=false
@@ -2917,8 +2916,7 @@ class CfgInf extends Message:
 
   Sets the type for all ports if $port is omitted.
   */
-  disable-all --port/int=PORT-ALL:
-    set-port-level port LEVEL-NONE
+  disable-all --port/int=PORT-ALL -> none: set-port-level port LEVEL-NONE
 
   /** The name of this messages' protocol. */
   proto-string_ -> string:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1561,7 +1561,7 @@ class NavPosLlh extends Message:
     return latitude-raw / DEGREES-SCALING-FACTOR_
 
   stringify -> string:
-    return  "$(super.stringify): {latitude:$(latitude-deg),longtidude:$(longitude-deg)}"
+    return  "$(super.stringify): {latitude:$(latitude-deg),longitude:$(longitude-deg)}"
 
 
 /**
@@ -1630,6 +1630,9 @@ class NavSvInfo extends Message:
   satellite-data index -> SatelliteData:
     if not 0 <= index < num-ch: throw "INVALID ARGUMENT"
     return SatelliteData index payload --src-id=ID
+
+  stringify -> string:
+    return  "$(super.stringify): satellite-count:$satellite-count|num-ch:$num-ch"
 
 
 /**
@@ -2040,6 +2043,9 @@ class NavSol extends Message:
   /** Reserved 2. */
   reserved2 -> int: return uint32_ 48      // U4 (M8 doc shows U1[4]; same 4 bytes).
 
+  stringify -> string:
+    return  "$(super.stringify): fix-type:$fix-type-text|num-sv:$num-sv"
+
 /**
 The UBX-NAV-TIMEUTC message.
 
@@ -2169,7 +2175,8 @@ class NavTimeUtc extends Message:
   utc-standard -> int:
     return (valid-flags-raw >> 4) & 0x0F
 
-
+  stringify -> string:
+    return  "$(super.stringify): valid-utc:$valid-utc|utc-time:$utc-time"
 
 /**
 The UBX-CFG-TP5 message.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -502,7 +502,7 @@ class Message:
       return Message.PACK-MESSAGE-TYPES[clsid][msgid]
     return "0x$(%02x msgid)"
 
-  /** Returns the message type in full UBX-* message name format. */
+  /** The message type name in full UBX-* format. */
   full-name -> string:
     return "UBX-$cls-string_-$id-string_"
 
@@ -739,7 +739,7 @@ class CfgMsg extends Message:
   is-poll -> bool:
     return payload.size == 2
 
-  /** Returns the string name of the given port. */
+  /** The string name of the given $port. */
   port-string_ port/int -> string:
     assert: port == PORT-ALL or 0 <= port <= 5
     return PACK-PORT-TYPES[port]
@@ -2871,13 +2871,13 @@ class CfgInf extends Message:
   disable-all --port/int=PORT-ALL:
     set-port-type --port=port --enable=null --type=MASK_NONE
 
-  /** Returns the string name of this messages' protocol. */
+  /** The string name of this messages' protocol. */
   proto-string_ -> string:
     if protocol-id == PROTO-UBX: return "UBX"
     if protocol-id == PROTO-NMEA: return "NMEA"
     return "UNKNOWN($protocol-id)"
 
-  /** Returns the string name of the given port. */
+  /** The string name of the given $port. */
   port-string_ port/int -> string:
     assert: port == PORT-ALL or 0 <= port <= 5
     return PACK-PORT-TYPES[port]

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -705,7 +705,7 @@ class CfgMsg extends Message:
     first.  Then change the required rates on the reply message, and send it
     back.
   */
-  constructor.message-rate --msg-class --msg-id --rate/int --port/int=-1:
+  constructor.message-rate --msg-class --msg-id --rate/int --port/int=PORT-ALL:
     assert: 0 <= msg-class <= 255
     assert: 0 <= msg-id <= 255
     assert: 0 <= rate <= 255
@@ -760,7 +760,7 @@ class CfgMsg extends Message:
 
   Sets the rate for all ports if $port is omitted.
   */
-  set-rate port/int=-1 --rate/int:
+  set-rate port/int=PORT-ALL --rate/int:
     assert: payload.size == 8
     assert: -1 <= port <= 5
     assert: 0 <= rate <= 0xFF
@@ -2846,11 +2846,11 @@ class CfgInf extends Message:
   debug-enabled port/int -> bool: return (get-port-type-mask port) & MASK-DEBUG   != 0
 
   // Helpers for enabling a given INF type on a port.
-  enable-error port/int=-1 -> none: set-port-type --port=port --enable --type=MASK-ERROR
-  enable-warning port/int=-1 -> none: set-port-type --port=port --enable --type=MASK-WARNING
-  enable-notice port/int=-1 -> none: set-port-type --port=port --enable --type=MASK-NOTICE
-  enable-test port/int=-1 -> none: set-port-type --port=port --enable --type=MASK-TEST
-  enable-debug port/int=-1 -> none: set-port-type --port=port --enable --type=MASK-DEBUG
+  enable-error port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-ERROR
+  enable-warning port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-WARNING
+  enable-notice port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-NOTICE
+  enable-test port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-TEST
+  enable-debug port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-DEBUG
   /**
   Disable all message types for a specific port.
 
@@ -2860,11 +2860,11 @@ class CfgInf extends Message:
     set-port-type --port=port --enable=null --type=MASK-ALL
 
   // Helpers for disabling a given INF type on a port.
-  disable-error port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-ERROR
-  disable-warning port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-WARNING
-  disable-notice port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-NOTICE
-  disable-test port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-TEST
-  disable-debug port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-DEBUG
+  disable-error port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-ERROR
+  disable-warning port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-WARNING
+  disable-notice port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-NOTICE
+  disable-test port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-TEST
+  disable-debug port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-DEBUG
   /**
   Disable all message types for a specific port.
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1500,7 +1500,7 @@ class MonVer extends Message:
     offset := 40
     field-size := 30
     num-extensions := (payload.size - offset) / field-size
-    num-extensions.repeat: | i |
+    num-extensions.repeat: | i/int |
       raw-extensions.add (convert-string_ (offset + (i * field-size)) field-size)
     return raw-extensions
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -559,6 +559,11 @@ class Message:
   /** Helper to read a '\0'-terminated string from the payload. */
   convert-string_ start/int length/int -> string:
     // Find first NUL within [start .. start+length].
+    assert: start >= 0
+    assert: length >= 0
+    assert: start + length <= payload.size
+    assert: payload.size > 0
+
     end := start + length
     pos := payload.index-of '\0' --from=start --to=end
     if pos > -1: end = pos
@@ -1468,6 +1473,10 @@ class MonVer extends Message:
   has-extension str/string -> bool:
     return extensions-raw.any: it.contains str
 
+  /** Whether this is a poll message (1-byte payload). */
+  is-poll -> bool:
+    return payload.size == 0
+
   /**
   The entire line of the extension with the given $str.
 
@@ -1495,6 +1504,7 @@ class MonVer extends Message:
 
   /** See $super. */
   stringify -> string:
+    if is-poll: return "$super: (poll)"
     return "$super: $sw-version|$hw-version"
 
 /**

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -769,20 +769,20 @@ class CfgMsg extends Message:
     else:
       put-uint8_ (2 + port) rate
 
-  // Convenience per-port accessors (only valid for Get/Set form).
-  get-rate-ddc   -> int: return get-rate PORT-DDC
+  // Convenience per-port setters/getters (only valid for get/set form).
+  get-rate-ddc -> int: return get-rate PORT-DDC
   get-rate-uart1 -> int: return get-rate PORT-UART1
   get-rate-uart2 -> int: return get-rate PORT-UART2
-  get-rate-usb   -> int: return get-rate PORT-USB
-  get-rate-spi   -> int: return get-rate PORT-SPI
-  get-rate-res5  -> int: return get-rate PORT-RES5
+  get-rate-usb -> int: return get-rate PORT-USB
+  get-rate-spi -> int: return get-rate PORT-SPI
+  get-rate-res5 -> int: return get-rate PORT-RES5
 
-  set-rate-ddc   rate/int -> none: set-rate PORT-DDC --rate=rate
+  set-rate-ddc rate/int -> none: set-rate PORT-DDC --rate=rate
   set-rate-uart1 rate/int -> none: set-rate PORT-UART1 --rate=rate
   set-rate-uart2 rate/int -> none: set-rate PORT-UART2 --rate=rate
-  set-rate-usb   rate/int -> none: set-rate PORT-USB --rate=rate
-  set-rate-spi   rate/int -> none: set-rate PORT-SPI --rate=rate
-  set-rate-res5  rate/int -> none: set-rate PORT-RES5 --rate=rate
+  set-rate-usb rate/int -> none: set-rate PORT-USB --rate=rate
+  set-rate-spi rate/int -> none: set-rate PORT-SPI --rate=rate
+  set-rate-res5 rate/int -> none: set-rate PORT-RES5 --rate=rate
 
   /** See $super. */
   stringify -> string:
@@ -2790,7 +2790,7 @@ class CfgInf extends Message:
     assert: -1 <= port <= 5
     set-port-type --port=port --enable=null --type=mask
 
-  // Convenience per-port accessors (only valid for Get/Set form).
+  // Convenience per-port getters/setters (only valid for Get/Set form).
   get-type-mask-ddc -> int: return get-port-type-mask PORT-DDC
   get-type-mask-uart1 -> int: return get-port-type-mask PORT-UART1
   get-type-mask-uart2 -> int: return get-port-type-mask PORT-UART2
@@ -2798,7 +2798,6 @@ class CfgInf extends Message:
   get-type-mask-spi -> int: return get-port-type-mask PORT-SPI
   get-type-mask-res5 -> int: return get-port-type-mask PORT-RES5
 
-  // Convenience per-port accessors (only valid for Get/Set form).
   set-type-mask-ddc mask/int -> none: set-port-type-mask PORT-DDC --mask=mask
   set-type-mask-uart1 mask/int -> none: set-port-type-mask PORT-UART1 --mask=mask
   set-type-mask-uart2 mask/int -> none: set-port-type-mask PORT-UART2 --mask=mask
@@ -2828,11 +2827,11 @@ class CfgInf extends Message:
     set-port-type --port=port --enable=null --type=MASK-ALL
 
   // Helpers for disabling a given INF type on a port.
-  disable-error   port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-ERROR
+  disable-error port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-ERROR
   disable-warning port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-WARNING
-  disable-notice  port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-NOTICE
-  disable-test    port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-TEST
-  disable-debug   port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-DEBUG
+  disable-notice port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-NOTICE
+  disable-test port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-TEST
+  disable-debug port/int=-1 -> none: set-port-type --port=port --no-enable --type=MASK-DEBUG
   /**
   Disable all message types for a specific port.
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -714,7 +714,7 @@ class CfgMsg extends Message:
     put-uint8_ 1 msg-id
     set-rate port --rate=rate
 
-  /** Poll the configuration. */
+  /** Constructs a message to retireve the current rate for $msg-class and $msg-id. */
   constructor.poll --msg-class --msg-id:
     super.private_ Message.CFG ID #[msg-class, msg-id]
 
@@ -910,7 +910,8 @@ class CfgPrt extends Message:
     put-uint16_ 18 0
 
   /**
-  Poll the configuration for a given port.
+  Constructs a message to retrieve the configuration for a $port-id.
+
   The poll payload is a single byte: $port-id, which must be one of
     $PORT-UART1, or $PORT-UART2.
   */
@@ -1042,7 +1043,7 @@ class NavStatus extends Message:
     TIME-ONLY: "TIME-ONLY",
   }
 
-  /** Constructs a message to poll for a UBX-NAV-STATUS message. */
+  /** Constructs a message to retrieve a UBX-NAV-STATUS message. */
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
@@ -1436,7 +1437,7 @@ class MonVer extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Constructs a poll-request UBX-MON-VER. */
+  /** Constructs a message to retrieve a UBX-MON-VER message. */
   constructor.poll:
     super.private_ Message.MON ID #[]
 
@@ -1677,7 +1678,7 @@ class NavPvt extends Message:
   /** Time only fix. */
   static TIME-ONLY ::= 5
 
-  /** Constructs a poll UBX-NAV-PVT message. */
+  /** Constructs a message to retrieve a UBX-NAV-PVT message. */
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
@@ -1936,7 +1937,7 @@ class NavSol extends Message:
     TIME-ONLY: "TIME-ONLY",
   }
 
-  /** Constructs a poll UBX-NAV-SOL message. */
+  /** Constructs a message to retrieve a UBX-NAV-SOL message. */
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
@@ -2093,7 +2094,7 @@ class NavTimeUtc extends Message:
   static WEEK-VALID-MASK_         ::= 0b00000010
   static UTC-VALID-MASK_          ::= 0b00000100
 
-  /** Constructs a poll UBX-NAV-TIMEUTC message. */
+  /** Constructs a message to retrieve a UBX-NAV-TIMEUTC message. */
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
@@ -2261,7 +2262,7 @@ class CfgTp5 extends Message:
   static FLAG-POLARITY-HI  ::= 0b00001000_00000000
   static FLAG-UTC-GRID     ::= 0b01000000_00000000
 
-  /** Poll the TP5 configuration for tpIdx (0 or 1). */
+  /** Constructs a message to retrieve the TP5 configuration for a given $tp-idx. */
   constructor.poll --tp-idx/int=TP-IDX-0:
     new-payload := ByteArray 2
     super.private_ Message.CFG ID new-payload
@@ -2420,7 +2421,7 @@ class CfgNav5 extends Message:
     DYN-AIR4G: "AIR4G"
   }
 
-  /** Poll current NAV5. */
+  /** Constructs a message to retrieve the current NAV5 configuration. */
   constructor.poll:
     super.private_ Message.CFG ID #[]
 
@@ -2586,7 +2587,7 @@ class CfgGnss extends Message:
   // Flags helpers.
   static FLAG-ENABLE ::= 1
 
-  /** Construct a poll message to get current GNSS configuration. */
+  /** Construct a poll message to retrieve the current GNSS configuration. */
   constructor.poll:
     // Empty payload poll (some firmwares accept either empty or msgVer=0).
     super.private_ Message.CFG ID #[]
@@ -2739,7 +2740,7 @@ class CfgInf extends Message:
   static MAX-PROTVER/string := "23.01"
 
   /**
-  Poll for the current INF configuration for a given protocol.
+  Retrieves the current INF configuration for a given $protocol-id.
 
   $protocol-id = one of $PROTO-UBX (0, default) to query UBX-INF-* enable masks,
     or $PROTO-NMEA (1) to query NMEA informational enable masks.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -556,7 +556,7 @@ class Message:
   put-uint32_ index value --payload=payload -> none:
     LITTLE-ENDIAN.put-uint32 payload index value
 
-  /** Helper to read a '\0'-terminated string from a larger byte array. */
+  /** Helper to read a '\0'-terminated string from the payload. */
   convert-string_ start/int length/int -> string:
     // Find first NUL within [start .. start+length].
     end := start + length
@@ -1453,12 +1453,10 @@ class MonVer extends Message:
     super.private_ Message.MON ID bytes
 
   /** Software version string. */
-  // Null terminated with fixed field size of 30 bytes.
   sw-version -> string:
     return convert-string_ 0 30
 
   /** Hardware version string. */
-  // Null terminated with fixed field size of 10 bytes.
   hw-version -> string:
     return convert-string_ 30 10
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -581,7 +581,7 @@ class AckAck extends Message:
     super.private_ Message.ACK ID #[cls, id]
 
   /** Construct an instance with bytes from a retrieved message. */
-  constructor.private_ payload:
+  constructor.private_ payload/ByteArray:
     super.private_ Message.ACK ID payload
 
   /** The class ID of the original message being ACK'ed. */
@@ -1048,7 +1048,7 @@ class NavStatus extends Message:
     super.private_ Message.NAV ID #[]
 
   /** Constructs a UBX-NAV-STATUS message from raw byte array. */
-  constructor.private_ payload:
+  constructor.private_ payload/ByteArray:
     super.private_ Message.NAV ID payload
 
   /** The GPS interval time of week of the navigation epoch. */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1126,6 +1126,9 @@ class NavStatus extends Message:
   ms-since-startup -> int:
     return uint32_ 12
 
+  stringify -> string:
+    return  "$(super.stringify): fix-type:$fix-type-text|ttff:$(Duration --ms=time-to-first-fix)"
+
 /**
 The UBX-NAV-SAT message.
 
@@ -1561,7 +1564,7 @@ class NavPosLlh extends Message:
     return latitude-raw / DEGREES-SCALING-FACTOR_
 
   stringify -> string:
-    return  "$(super.stringify): {latitude:$(latitude-deg),longitude:$(longitude-deg)}"
+    return  "$(super.stringify): latitude:$(latitude-deg)|longitude:$(longitude-deg)"
 
 
 /**
@@ -1777,9 +1780,19 @@ class NavPvt extends Message:
   lon -> int:
     return int32_ 24
 
+  /** Convenience method for $lon. */
+  // To match message type 'UBX-NAV-POSLLH'.
+  longitude -> int:
+    return lon
+
   /** Latitude. */
   lat -> int:
     return int32_ 28
+
+  /** Convenience method for $lat. */
+  // To match message type 'UBX-NAV-POSLLH'.
+  latitude -> int:
+    return lat
 
   /** Height above ellipsoid in millimeter. */
   height -> int:
@@ -1862,6 +1875,9 @@ class NavPvt extends Message:
   */
   magnetic-acc -> int:
     return uint16_ 90
+
+  stringify -> string:
+    return  "$(super.stringify): latitude:$(latitude)|longitude:$(longitude)"
 
 
 /**
@@ -2864,7 +2880,7 @@ class CfgInf extends Message:
 
   /** See $super. */
   stringify -> string:
-    out-str := "$(super.stringify): [$(proto-string_)]"
+    out-str := "$(super.stringify): {$(proto-string_)}"
     if is-poll:
       return "$out-str (poll)"
     6.repeat:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2673,9 +2673,6 @@ class CfgGnss extends Message:
     block["flags"] = uint32_ (base + BLOCK-FLAGS_)
     return block
 
-
-
-
 /**
 The UBX-CFG-INF message.
 
@@ -2745,8 +2742,7 @@ class CfgInf extends Message:
   Poll for the current INF configuration for a given protocol.
 
   $protocol-id = one of $PROTO-UBX (0, default) to query UBX-INF-* enable masks,
-    or $PROTO-NMEA (1) to query NMEA informational enable masks.  Returned
-    message is fixed for the protocol requested.
+    or $PROTO-NMEA (1) to query NMEA informational enable masks.
   */
   constructor.poll --protocol-id/int=PROTO-UBX:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -580,9 +580,9 @@ class AckAck extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.ACK ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.ACK ID bytes
 
   /** The class ID of the original message being ACK'ed. */
   class-id -> int:
@@ -628,9 +628,9 @@ class AckNak extends Message:
   constructor.private_ cls id:
     super.private_ Message.ACK ID #[cls, id]
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.ACK ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.ACK ID bytes
 
   /** The class ID of the original message being NAK'ed. */
   class-id -> int:
@@ -725,9 +725,9 @@ class CfgMsg extends Message:
     assert: rates.size == 6
     super.private_ Message.CFG ID (#[msg-class, msg-id] + rates)
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.CFG ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.CFG ID bytes
 
   class-id -> int:
     return uint8_ 0
@@ -917,9 +917,9 @@ class CfgPrt extends Message:
   constructor.poll --port-id/int=PORT-UART1:
     super.private_ Message.CFG ID #[port-id]
 
-  /** Construct from an incoming payload. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.CFG ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.CFG ID bytes
 
   /**
   Ublox internal port ID.
@@ -1046,9 +1046,9 @@ class NavStatus extends Message:
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
-  /** Constructs a UBX-NAV-STATUS message from raw byte array. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** The GPS interval time of week of the navigation epoch. */
   itow -> int:
@@ -1152,8 +1152,9 @@ class NavSat extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** The GPS interval time of week of the navigation epoch. */
   itow -> int:
@@ -1439,9 +1440,9 @@ class MonVer extends Message:
   constructor.poll:
     super.private_ Message.MON ID #[]
 
-  /** Construct from an incoming payload. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.MON ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.MON ID bytes
 
   /** Software version string. */
   // Null terminated with fixed field size of 30 bytes.
@@ -1523,8 +1524,9 @@ class NavPosLlh extends Message:
 
   static DEGREES-SCALING-FACTOR_ ::= 1e7
 
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** GPS time of week of the navigation epoch. */
   itow -> int:
@@ -1590,8 +1592,9 @@ class NavSvInfo extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** The GPS interval time of week of the navigation epoch. (ms). */
   itow -> int:
@@ -1678,8 +1681,9 @@ class NavPvt extends Message:
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** Whether this is a GNSS fix. */
   is-gnss-fix -> bool:
@@ -1936,8 +1940,9 @@ class NavSol extends Message:
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** Whether this is a GNSS fix. */
   is-gnss-fix -> bool:
@@ -2092,8 +2097,9 @@ class NavTimeUtc extends Message:
   constructor.poll:
     super.private_ Message.NAV ID #[]
 
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.NAV ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.NAV ID bytes
 
   /** The GPS interval time of week of the navigation epoch. */
   itow -> int:
@@ -2262,9 +2268,9 @@ class CfgTp5 extends Message:
     put-uint8_ 0 tp-idx
     put-uint8_ 1 1  // Version.
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.CFG ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.CFG ID bytes
 
   /**
   Set TP5, starting with common defaults:
@@ -2418,9 +2424,9 @@ class CfgNav5 extends Message:
   constructor.poll:
     super.private_ Message.CFG ID #[]
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.CFG ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.CFG ID bytes
 
   /** Minimal setter: set dyn model + auto 2D/3D, leave others default. */
   constructor.set-basic
@@ -2585,9 +2591,9 @@ class CfgGnss extends Message:
     // Empty payload poll (some firmwares accept either empty or msgVer=0).
     super.private_ Message.CFG ID #[]
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.CFG ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.CFG ID bytes
 
   /** Build from a list of 8-byte blocks. numTrkChHw/Use are advisory. */
   constructor.set
@@ -2759,9 +2765,9 @@ class CfgInf extends Message:
     super.private_ Message.CFG ID (ByteArray 10)
     put-uint8_ 0 protocol-id
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.CFG ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.CFG ID bytes
 
   /** True if this is a poll message (1-byte payload). */
   is-poll -> bool:
@@ -2915,9 +2921,9 @@ class InfError extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.INF ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.INF ID bytes
 
   /** The informational text payload (NUL-terminated or raw). */
   text -> string:
@@ -2958,9 +2964,9 @@ class InfWarning extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.INF ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.INF ID bytes
 
   /** The informational text payload (NUL-terminated or raw). */
   text -> string:
@@ -3001,9 +3007,9 @@ class InfNotice extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.INF ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.INF ID bytes
 
   /** The informational text payload (NUL-terminated or raw). */
   text -> string:
@@ -3044,9 +3050,9 @@ class InfTest extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.INF ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.INF ID bytes
 
   /** The informational text payload (NUL-terminated or raw). */
   text -> string:
@@ -3087,9 +3093,9 @@ class InfDebug extends Message:
   */
   static MAX-PROTVER/string := ""
 
-  /** Constructs an instance with the $payload bytes from a retrieved message. */
-  constructor.private_ payload/ByteArray:
-    super.private_ Message.INF ID payload
+  /** Constructs an instance with the payload $bytes from a retrieved message. */
+  constructor.private_ bytes/ByteArray:
+    super.private_ Message.INF ID bytes
 
   /** The informational text payload (NUL-terminated or raw). */
   text -> string:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2920,11 +2920,11 @@ class CfgInf extends Message:
 /**
 The UBX-INF-ERROR message.
 
-Asynchronous human-readable text message, emitted by the receiver (if
-  configured) when an error condition occurs in the UBX firmware.
+Asynchronous human-readable text message emitted by the receiver (if
+  configured) when an error condition occurs in the ublox firmware.
 
-UBX-INF-* messages are not pollable. They are enabled/disabled via configuration
-  (VALSET 'CFG-INFMSG' keys, or using  UBX-CFG-INF M8/older devices).
+This message is not pollable.  It is enabled/disabled via configuration using
+  $CfgInf (UBX-CFG-INF).
 */
 class InfError extends Message:
   /** The UBX-INF-ERROR message ID. */
@@ -2961,11 +2961,11 @@ class InfError extends Message:
 /**
 The UBX-INF-WARNING message.
 
-Asynchronous human-readable text message, emitted by the receiver (if
-  configured) for warnings.
+Asynchronous human-readable text message emitted by the receiver (if configured)
+  for ublox-sourced warnings.
 
-UBX-INF-* messages are not pollable. They are enabled/disabled via configuration
-  (VALSET 'CFG-INFMSG' keys, or using UBX-CFG-INF M8/older devices).
+This message is not pollable.  It is enabled/disabled via configuration using
+  $CfgInf (UBX-CFG-INF).
 */
 class InfWarning extends Message:
   /** The UBX-INF-WARNING message ID. */
@@ -3002,11 +3002,11 @@ class InfWarning extends Message:
 /**
 The UBX-INF-NOTICE message.
 
-Asynchronous human-readable text message, emitted by the receiver for notices
-  (if configured).
+Asynchronous human-readable text message, emitted by the receiver for ublox-
+  sourced notice output (if configured).
 
-UBX-INF-* messages are not pollable. They are enabled/disabled via configuration
-  (VALSET 'CFG-INFMSG' keys, or using UBX-CFG-INF M8/older devices).
+This message is not pollable.  It is enabled/disabled via configuration using
+  $CfgInf (UBX-CFG-INF).
 */
 class InfNotice extends Message:
   /** The UBX-INF-NOTICE message ID. */
@@ -3044,10 +3044,10 @@ class InfNotice extends Message:
 The UBX-INF-TEST message.
 
 Asynchronous human-readable text message, emitted by the receiver (if
-  configured) for test output.
+  configured) for ublox-sourced test output.
 
-UBX-INF-* messages are not pollable. They are enabled/disabled via configuration
-  (VALSET 'CFG-INFMSG' keys, or using UBX-CFG-INF M8/older devices).
+This message is not pollable.  It is enabled/disabled via configuration using
+  $CfgInf (UBX-CFG-INF).
 */
 class InfTest extends Message:
   /** The UBX-INF-TEST message ID. */
@@ -3085,10 +3085,10 @@ class InfTest extends Message:
 The UBX-INF-DEBUG message.
 
 Asynchronous human-readable text message, emitted by the receiver (if
-  configured) for debug output.
+  configured) for ublox-sourced debug output.
 
-UBX-INF-* messages are not pollable. They are enabled/disabled via configuration
-  (VALSET 'CFG-INFMSG' keys, or using UBX-CFG-INF M8/older devices).
+This message is not pollable.  It is enabled/disabled via configuration using
+  $CfgInf (UBX-CFG-INF).
 */
 class InfDebug extends Message:
   /** The UBX-INF-DEBUG message ID. */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -758,7 +758,7 @@ class CfgMsg extends Message:
   /**
   Sets the rate for the message type for the specified $port.
 
-  Omit $port to set for all types.
+  Sets the rate for all ports if $port is omitted.
   */
   set-rate port/int=-1 --rate/int:
     assert: payload.size == 8
@@ -2782,15 +2782,16 @@ class CfgInf extends Message:
   /**
   Configure enable/disable on a specific message type for a specific port.
 
-  Omit $port to set for all types. Use --enable or --no-enable to set.
+  Sets the type for all ports if $port is omitted. Use --enable or --no-enable to set.
   */
   set-port-type --port/int=-1 --type/int --enable/bool?=true:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA
     assert: -1 <= port <= 5
     assert: 0 <= type <= 0xFF
 
-    // if $enable is null, replace instead of adjusting the existing value.
-    if port == -1:  //
+    // if $enable is null, the value is replaced, instead of adjusting bits in
+    // the existing value using the mask.
+    if port == -1:
       6.repeat:
         if enable == null: put-uint8_ (4 + it) type
         else if enable: put-uint8_ (4 + it) ((uint8_ (4 + it)) | type)
@@ -2853,7 +2854,7 @@ class CfgInf extends Message:
   /**
   Disable all message types for a specific port.
 
-  Omit $port to set for all ports.
+  Sets the type for all ports if $port is omitted.
   */
   enable-all --port/int=-1:
     set-port-type --port=port --enable=null --type=MASK-ALL
@@ -2867,7 +2868,7 @@ class CfgInf extends Message:
   /**
   Disable all message types for a specific port.
 
-  Omit $port to set for all ports.
+  Sets the type for all ports if $port is omitted.
   */
   disable-all --port/int=-1:
     set-port-type --port=port --enable=null --type=MASK_NONE

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2850,7 +2850,7 @@ class CfgInf extends Message:
   enable-test port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-TEST
   enable-debug port/int=PORT-ALL -> none: set-port-type --port=port --enable --type=MASK-DEBUG
   /**
-  Disable all message types for a specific port.
+  Enables all message types for the given $port.
 
   Sets the type for all ports if $port is omitted.
   */
@@ -2864,7 +2864,7 @@ class CfgInf extends Message:
   disable-test port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-TEST
   disable-debug port/int=PORT-ALL -> none: set-port-type --port=port --no-enable --type=MASK-DEBUG
   /**
-  Disable all message types for a specific port.
+  Disables all message types for the given $port.
 
   Sets the type for all ports if $port is omitted.
   */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -766,7 +766,7 @@ class CfgMsg extends Message:
     assert: 0 <= rate <= 0xFF
 
     // if $enable is null, replace instead of adjusting the existing value.
-    if port == -1:  //
+    if port == PORT-ALL:  //
       6.repeat:
         put-uint8_ (2 + it) rate
     else:
@@ -2791,7 +2791,7 @@ class CfgInf extends Message:
 
     // if $enable is null, the value is replaced, instead of adjusting bits in
     // the existing value using the mask.
-    if port == -1:
+    if port == PORT-ALL:
       6.repeat:
         if enable == null: put-uint8_ (4 + it) type
         else if enable: put-uint8_ (4 + it) ((uint8_ (4 + it)) | type)

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2629,11 +2629,12 @@ class CfgInf extends Message:
     super.private_ Message.CFG ID #[protocol-id]
 
   /**
-  Construct a blank instance.
+  Construct a blank instance of UBX-CFG-INF.
 
-  Warning: If sent, would overwrite current configuration, not edit it.  To edit
-    the current configuration, poll for this message, and use the methods on
-    the UBX-CFG-INF response message.
+  Warning: If sent, configurations present in this message would overwrite the
+    current configuration, not edit it.  To edit the current configuration,
+    poll for this message, and use the methods in the response message.  Then
+    send that message back as a configuration message.
   */
   constructor --protocol-id/int=PROTO-UBX:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -772,7 +772,7 @@ class CfgMsg extends Message:
     else:
       put-uint8_ (2 + port) rate
 
-  // Convenience per-port setters/getters (only valid for get/set form).
+  // Convenience per-port setters/getters.
   get-rate-ddc -> int: return get-rate PORT-DDC
   get-rate-uart1 -> int: return get-rate PORT-UART1
   get-rate-uart2 -> int: return get-rate PORT-UART2
@@ -2823,7 +2823,7 @@ class CfgInf extends Message:
     assert: -1 <= port <= 5
     set-port-type --port=port --enable=null --type=mask
 
-  // Convenience per-port getters/setters (only valid for Get/Set form).
+  // Convenience per-port getters/setters.
   get-type-mask-ddc -> int: return get-port-type-mask PORT-DDC
   get-type-mask-uart1 -> int: return get-port-type-mask PORT-UART1
   get-type-mask-uart2 -> int: return get-port-type-mask PORT-UART2

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -1189,6 +1189,10 @@ class NavSat extends Message:
     if not 0 <= index < num-svs: throw "INVALID ARGUMENT"
     return SatelliteData index payload --src-id=ID
 
+  /** See $super. */
+  stringify -> string:
+    return "$super: satellite-count:$satellite-count"
+
 /**
 Satellite data for a single satellite.
 
@@ -2785,7 +2789,8 @@ class CfgInf extends Message:
     assert: 0 <= level <= 0x1F
 
     if port == PORT-ALL:
-      6.repeat:
+      // Deliberately misses port PORT-RES5 as stated in the manual.
+      5.repeat:
         if enable: put-uint8_ (4 + it) ((uint8_ (4 + it)) | level)
         else: put-uint8_ (4 + it) ((uint8_ (4 + it)) & (~level & 0xFF))
     else:
@@ -2804,7 +2809,8 @@ class CfgInf extends Message:
     assert: 0 <= raw-value <= 0x1F
 
     if port == PORT-ALL:
-      6.repeat:
+      // Deliberately misses port PORT-RES5, as stipluated in the manual.
+      5.repeat:
         put-uint8_ (4 + it) raw-value
     else:
       put-uint8_ (4 + port) raw-value

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2772,7 +2772,7 @@ class CfgInf extends Message:
     return payload.size == 1
 
   /**
-  Returns which protocol of this (0=UBX, 1=NMEA).
+  The protocol ($PROTO-UBX, or $PROTO-NMEA).
   */
   protocol-id -> int:
     return uint8_ 0

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2701,7 +2701,7 @@ This message type polls, gets and sets the configuration for UBX-CFG-* message
   types.  It controls whether UBX-INF-* (and/or NMEA informational) messages
   are emitted, and on which interface/port.
 
-  These types are acsynchronous human-readable text messages, emitted
+  These types are asynchronous human-readable text messages, emitted
   by the receiver when an error condition occurs.  The UBX-INF-* message types
   cannot be directly polled for.
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2385,7 +2385,6 @@ class CfgNav5 extends Message:
     DYN-AIR4G: "AIR4G"
   }
 
-
   /** Poll current NAV5. */
   constructor.poll:
     super.private_ Message.CFG ID #[]
@@ -2655,18 +2654,6 @@ This message type polls, gets and sets the configuration for UBX-CFG-* message
 
 This message type is used for M8 or lower devices, for higher devices use the
   VALGET/VALSET/VALDEL configuration mechanism.
-*/
-/*
-Payload (Get/Set, 10 bytes):
-  U1   protocolID        (0=UBX, 1=NMEA)
-  U1   reserved1[3]      (0)
-  X1   infMsgMask[6]     (bitmask per port)
-
-Poll payload (1 byte):
-  U1   protocolID
-
-Port index mapping (eg, M8):
-  0=DDC (I2C), 1=UART1, 2=UART2, 3=USB, 4=SPI, 5=reserved.
 */
 class CfgInf extends Message:
   /** The UBX-CFG-INF message ID. */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -558,7 +558,7 @@ class Message:
 
   /** Helper to read a '\0'-terminated string from the payload. */
   convert-string_ start/int length/int -> string:
-    // Find first NUL within [start .. start+length].
+    // Find first '\0' within [start .. start+length].
     assert: start >= 0
     assert: length >= 0
     assert: start + length <= payload.size

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2571,7 +2571,7 @@ class CfgGnss extends Message:
 
     blocks.size.repeat: | i/int |
       block := blocks[i]  // Expect map with fields: "gnssId", "resTrkCh", "maxTrkCh", "flags"
-      assert: block.size = 5
+      assert: block.size == 5
       base := 4 + 8 * i
       put-uint8_ (base + BLOCK-GNSSID_) block["gnssId"]
       put-uint8_ (base + BLOCK-RESTRKCH_) block["resTrkCh"]
@@ -2769,11 +2769,11 @@ class CfgInf extends Message:
       6.repeat:
         if enable == null: put-uint8_ (4 + it) type
         else if enable: put-uint8_ (4 + it) ((uint8_ (4 + it)) | type)
-        else: put-uint8_ (4 + it) ((uint8_ (4 + it)) & ~type)
+        else: put-uint8_ (4 + it) ((uint8_ (4 + it)) & (~type & 0xFF))
     else:
       if enable == null: put-uint8_ (4 + port) type
       else if enable: put-uint8_ (4 + port) ((uint8_ (4 + port)) | type)
-      else: put-uint8_ (4 + port) ((uint8_ (4 + port)) & ~type)
+      else: put-uint8_ (4 + port) ((uint8_ (4 + port)) & (~type & 0xFF))
 
   /**
   Gets the mask byte for the given $port.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2717,6 +2717,8 @@ class CfgInf extends Message:
     PORT-RES5: "RES5",
   }
 
+  static ENABLED ::= true
+  static DISABLED ::= false
   /**
   The minimum protocol version for the message type.
 
@@ -2773,11 +2775,11 @@ class CfgInf extends Message:
   /**
   Configure enable/disable on a specific log $level for a specific $port.
 
-  Sets the logging $level for all ports if $port is omitted. Use --enable or
-    --no-enable to set the level.  Logging $level should be one of  $LEVEL-ERROR,
-    $LEVEL-WARNING, $LEVEL-NOTICE, $LEVEL-TEST, or $LEVEL-DEBUG.
+  Sets the logging $level for all ports if $port is omitted. Logging $level
+    should be one of  $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE, $LEVEL-TEST,
+    or $LEVEL-DEBUG.
   */
-  set-port-level port/int=PORT-ALL --level/int --enable/bool=true -> none:
+  set-port-level port/int=PORT-ALL --level/int enable/bool=true -> none:
     assert: protocol-id == PROTO-UBX or protocol-id == PROTO-NMEA
     assert: port == PORT-ALL or 0 <= port <= 5
     assert: 0 <= level <= 0x1F
@@ -2841,11 +2843,11 @@ class CfgInf extends Message:
   debug-enabled port/int -> bool: return (get-port-level-raw port) & LEVEL-DEBUG != 0
 
   // Helpers for enabling a given INF type on a port.
-  enable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR --enable
-  enable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING --enable
-  enable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE --enable
-  enable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST --enable
-  enable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG --enable
+  enable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR ENABLED
+  enable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING ENABLED
+  enable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE ENABLED
+  enable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST ENABLED
+  enable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG ENABLED
   /**
   Enables all message types for the given $port.
 
@@ -2855,11 +2857,11 @@ class CfgInf extends Message:
     set-port-level port --level=LEVEL-ALL
 
   // Helpers for disabling a given INF type on a port.
-  disable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR --no-enable
-  disable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING --no-enable
-  disable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE --no-enable
-  disable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST --no-enable
-  disable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG --no-enable
+  disable-error port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-ERROR DISABLED
+  disable-warning port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-WARNING DISABLED
+  disable-notice port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-NOTICE DISABLED
+  disable-test port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-TEST DISABLED
+  disable-debug port/int=PORT-ALL -> none: set-port-level port --level=LEVEL-DEBUG DISABLED
   /**
   Disables all message types for the given $port.
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -698,8 +698,7 @@ class CfgMsg extends Message:
   /**
   Constructs a blank configuration-rate message.
 
-  Examine/configure this message using the supplied getters and setters.  If
-    sent to the device it may overwrite the rates for all ports for the
+  When sent to the device it will overwrite the rates for all ports for the
     specified message type.
 
   In order to edit rates (as opposed to replacing them) poll for this message

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -718,7 +718,7 @@ class CfgMsg extends Message:
   constructor.poll --msg-class --msg-id:
     super.private_ Message.CFG ID #[msg-class, msg-id]
 
-  /** Set all port rates at once using 6*byte byte array ($rates). */
+  /** Set all port rates at once using byte array ($rates) with 6 entries. */
   constructor.per-port --msg-class/int --msg-id/int --rates/ByteArray:
     assert: 0 <= msg-class <= 255
     assert: 0 <= msg-id <= 255

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2788,7 +2788,7 @@ class CfgInf extends Message:
     return uint8_ 0
 
   /**
-  Configure enable/disable on a specific log $level for a specific $port.
+  Enable or disable) a specific logging $level, for a specific $port.
 
   Sets the logging $level for all ports if $port is omitted. Logging $level
     should be one of  $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE, $LEVEL-TEST,

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -502,9 +502,13 @@ class Message:
       return Message.PACK-MESSAGE-TYPES[clsid][msgid]
     return "0x$(%02x msgid)"
 
+  /** Return message type in full UBX-* message name format. */
+  full-name -> string:
+    return "UBX-$cls-string_-$id-string_"
+
   /** See $super. */
   stringify -> string:
-    return "UBX-$cls-string_-$id-string_"
+    return full-name
 
   /** Hash code for use as an identifier in a Map. */
   hash-code:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2822,7 +2822,7 @@ class CfgInf extends Message:
   /**
   Sets the raw logging level mask byte the given $port.
 
-  $raw-value is a mask of all the bits of the requested levels combined.
+  $raw-value is a bitmask of all the bits of the requested levels combined.
     Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
     $LEVEL-TEST, and $LEVEL-DEBUG.
 
@@ -2843,6 +2843,10 @@ class CfgInf extends Message:
 
   /**
   Gets the raw logging level mask byte the given $port.
+
+  Output is a bitmask of all the bits of the requested levels combined.
+    Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
+    $LEVEL-TEST, and $LEVEL-DEBUG.
 
   The $port parameter must be one of $PORT-DDC(0), $PORT-UART1(1),
     $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -502,7 +502,7 @@ class Message:
       return Message.PACK-MESSAGE-TYPES[clsid][msgid]
     return "0x$(%02x msgid)"
 
-  /** Return message type in full UBX-* message name format. */
+  /** Returns the message type in full UBX-* message name format. */
   full-name -> string:
     return "UBX-$cls-string_-$id-string_"
 

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -556,6 +556,14 @@ class Message:
   put-uint32_ index value --payload=payload -> none:
     LITTLE-ENDIAN.put-uint32 payload index value
 
+  /** Helper to read a '\0'-terminated string from a larger byte array. */
+  convert-string_ start/int length/int -> string:
+    // Find first NUL within [start .. start+length].
+    end := start + length
+    pos := payload.index-of 0x00 --from=start --to=end
+    if pos > -1: end = start + pos
+    return (payload[start..end]).to-string
+
 /**
 The UBX-ACK-ACK message.
 
@@ -1483,18 +1491,6 @@ class MonVer extends Message:
       raw-extensions.add (convert-string_ offset 30)
       offset += 30
     return raw-extensions
-
-
-  /** Helper: read a '\0'-terminated string from a fixed-size field. */
-  convert-string_ start length -> string:
-    // Find first NUL within [start .. start+length).
-    end := start
-    limit := start + length
-    while (end < limit) and (uint8_ end) != 0:
-      end++
-
-    // Slice bytes [start .. end) and convert to a Toit string.
-    return (payload[start..end]).to-string
 
   /** See $super. */
   stringify -> string:
@@ -2924,9 +2920,9 @@ class InfError extends Message:
   constructor.private_ bytes/ByteArray:
     super.private_ Message.INF ID bytes
 
-  /** The informational text payload (NUL-terminated or raw). */
+  /** The text payload. */
   text -> string:
-    return (payload[0..payload.size]).to-string-non-throwing
+    return convert-string_ 0 payload.size
 
   /** See $super. */
   stringify -> string:
@@ -2965,9 +2961,9 @@ class InfWarning extends Message:
   constructor.private_ bytes/ByteArray:
     super.private_ Message.INF ID bytes
 
-  /** The informational text payload (NUL-terminated or raw). */
+  /** The text payload. */
   text -> string:
-    return (payload[0..payload.size]).to-string-non-throwing
+    return convert-string_ 0 payload.size
 
   /** See $super. */
   stringify -> string:
@@ -3006,9 +3002,9 @@ class InfNotice extends Message:
   constructor.private_ bytes/ByteArray:
     super.private_ Message.INF ID bytes
 
-  /** The informational text payload (NUL-terminated or raw). */
+  /** The text payload. */
   text -> string:
-    return (payload[0..payload.size]).to-string-non-throwing
+    return convert-string_ 0 payload.size
 
   /** See $super. */
   stringify -> string:
@@ -3047,9 +3043,9 @@ class InfTest extends Message:
   constructor.private_ bytes/ByteArray:
     super.private_ Message.INF ID bytes
 
-  /** The informational text payload (NUL-terminated or raw). */
+  /** The text payload. */
   text -> string:
-    return (payload[0..payload.size]).to-string-non-throwing
+    return convert-string_ 0 payload.size
 
   /** See $super. */
   stringify -> string:
@@ -3088,9 +3084,9 @@ class InfDebug extends Message:
   constructor.private_ bytes/ByteArray:
     super.private_ Message.INF ID bytes
 
-  /** The informational text payload (NUL-terminated or raw). */
+  /** The text payload. */
   text -> string:
-    return (payload[0..payload.size]).to-string-non-throwing
+    return convert-string_ 0 payload.size
 
   /** See $super. */
   stringify -> string:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -602,7 +602,7 @@ class AckAck extends Message:
 
   /** See $super. */
   stringify -> string:
-    return  "$(super.stringify): {0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)($(id-string_ class-id message-id))}"
+    return  "$super: {0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)($(id-string_ class-id message-id))}"
 
 /**
 The UBX-ACK-NAK message.
@@ -650,7 +650,7 @@ class AckNak extends Message:
 
   /** See $super. */
   stringify -> string:
-    return  "$(super.stringify): {0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)(:$(id-string_ class-id message-id))}"
+    return  "$super: {0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)(:$(id-string_ class-id message-id))}"
 
 /**
 The UBX-CFG-MSG message.
@@ -789,7 +789,7 @@ class CfgMsg extends Message:
 
   /** See $super. */
   stringify -> string:
-    out-str := "$(super.stringify)"
+    out-str := "$super"
     if is-poll:
       return "$out-str: {poll}"
     out-str += ": {0x$(%02x class-id)($(cls-string_ class-id)):0x$(%02x message-id)($(id-string_ class-id message-id))}"
@@ -1127,7 +1127,7 @@ class NavStatus extends Message:
     return uint32_ 12
 
   stringify -> string:
-    return  "$(super.stringify): fix-type:$fix-type-text|ttff:$(Duration --ms=time-to-first-fix)"
+    return  "$super: fix-type:$fix-type-text|ttff:$(Duration --ms=time-to-first-fix)"
 
 /**
 The UBX-NAV-SAT message.
@@ -1411,7 +1411,7 @@ class SatelliteData:
     // TODO(kasper): Make this output a whole lot prettier and easier to parse.
     //          ian: Added class/id type string from $super to assist with
     //               tests.  Would be cool to standardise them somehow...?
-    return "$(super.stringify): $index|$gnss-id|$sv-id|$cno|$quality|$orbit-source|$codes"
+    return "$super: $index|$gnss-id|$sv-id|$cno|$quality|$orbit-source|$codes"
 
 /**
 The UBX-MON-VER message.
@@ -1498,7 +1498,7 @@ class MonVer extends Message:
 
   /** See $super. */
   stringify -> string:
-    return "$(super.stringify): $sw-version|$hw-version"
+    return "$super: $sw-version|$hw-version"
 
 /**
 The UBX-NAV-POSLLH message.
@@ -1566,7 +1566,7 @@ class NavPosLlh extends Message:
     return latitude-raw / DEGREES-SCALING-FACTOR_
 
   stringify -> string:
-    return  "$(super.stringify): latitude:$(latitude-deg)|longitude:$(longitude-deg)"
+    return  "$super: latitude:$(latitude-deg)|longitude:$(longitude-deg)"
 
 
 /**
@@ -1638,7 +1638,7 @@ class NavSvInfo extends Message:
     return SatelliteData index payload --src-id=ID
 
   stringify -> string:
-    return  "$(super.stringify): satellite-count:$satellite-count|num-ch:$num-ch"
+    return  "$super: satellite-count:$satellite-count|num-ch:$num-ch"
 
 
 /**
@@ -1881,7 +1881,7 @@ class NavPvt extends Message:
     return uint16_ 90
 
   stringify -> string:
-    return  "$(super.stringify): latitude:$(latitude)|longitude:$(longitude)"
+    return  "$super: latitude:$(latitude)|longitude:$(longitude)"
 
 
 /**
@@ -2065,7 +2065,7 @@ class NavSol extends Message:
   reserved2 -> int: return uint32_ 48      // U4 (M8 doc shows U1[4]; same 4 bytes).
 
   stringify -> string:
-    return  "$(super.stringify): fix-type:$fix-type-text|num-sv:$num-sv"
+    return  "$super: fix-type:$fix-type-text|num-sv:$num-sv"
 
 /**
 The UBX-NAV-TIMEUTC message.
@@ -2198,7 +2198,7 @@ class NavTimeUtc extends Message:
     return (valid-flags-raw >> 4) & 0x0F
 
   stringify -> string:
-    return  "$(super.stringify): valid-utc:$valid-utc|utc-time:$utc-time"
+    return  "$super: valid-utc:$valid-utc|utc-time:$utc-time"
 
 /**
 The UBX-CFG-TP5 message.
@@ -2884,7 +2884,7 @@ class CfgInf extends Message:
 
   /** See $super. */
   stringify -> string:
-    out-str := "$(super.stringify): {$(proto-string_)}"
+    out-str := "$super: {$(proto-string_)}"
     if is-poll:
       return "$out-str (poll)"
     6.repeat:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -739,7 +739,7 @@ class CfgMsg extends Message:
   is-poll -> bool:
     return payload.size == 2
 
-  /** The string name of the given $port. */
+  /** The name of the given $port. */
   port-string_ port/int -> string:
     assert: port == PORT-ALL or 0 <= port <= 5
     return PACK-PORT-TYPES[port]
@@ -2871,13 +2871,13 @@ class CfgInf extends Message:
   disable-all --port/int=PORT-ALL:
     set-port-type --port=port --enable=null --type=MASK_NONE
 
-  /** The string name of this messages' protocol. */
+  /** The name of this messages' protocol. */
   proto-string_ -> string:
     if protocol-id == PROTO-UBX: return "UBX"
     if protocol-id == PROTO-NMEA: return "NMEA"
     return "UNKNOWN($protocol-id)"
 
-  /** The string name of the given $port. */
+  /** The name of the given $port. */
   port-string_ port/int -> string:
     assert: port == PORT-ALL or 0 <= port <= 5
     return PACK-PORT-TYPES[port]

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2704,9 +2704,6 @@ This message type polls, gets and sets the configuration for UBX-CFG-* message
   These types are asynchronous human-readable text messages, emitted
   by the receiver when an error condition occurs.  The UBX-INF-* message types
   cannot be directly polled for.
-
-This message type is used for M8 or lower devices, for higher devices use the
-  VALGET/VALSET/VALDEL configuration mechanism.
 */
 class CfgInf extends Message:
   /** The UBX-CFG-INF message ID. */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2799,9 +2799,10 @@ class CfgInf extends Message:
   /**
   Enable (or disable) a specific logging $level, for a specific $port.
 
-  Adds or removes the given $level bit from the ports' bitmask.  This method
-    does not replace other bits that might be set ($set-port-level replaces the
-    entire mask).  Use $enable to set or unset the desired bit.
+  Adds or removes the given $level bit from the ports' bitmask of enabled
+    logging levels.  Use $enable to set or unset the desired $level. (This
+    method does not replace other bits that might be set. In comparison,
+    $set-port-level replaces the entire bitmask with the new value).
 
   Sets the logging $level for all ports if $port is omitted. Logging $level
     should be one of  $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE, $LEVEL-TEST,

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2822,6 +2822,10 @@ class CfgInf extends Message:
   /**
   Sets the raw logging level mask byte the given $port.
 
+  $raw-value is a mask of all the bits of the requested levels combined.
+    Individual bits are given by $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE
+    $LEVEL-TEST, and $LEVEL-DEBUG.
+
   $port must be one of  $PORT-ALL(-1), $PORT-DDC(0), $PORT-UART1(1),
     $PORT-UART2(2), $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
   */

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2805,8 +2805,8 @@ class CfgInf extends Message:
     set $raw instead.
 
   Sets the logging $level for all ports if $port is omitted.  $port must be one
-    of  $PORT-ALL(-1), $PORT-DDC(0), $PORT-UART1(1), $PORT-UART2(2),
-    $PORT-USB(3), $PORT-SPI(4), $PORT-RES5(5).
+    of $PORT-ALL, $PORT-DDC, $PORT-UART1, $PORT-UART2,
+    $PORT-USB, $PORT-SPI, $PORT-RES5.
 
   Logging $level should be one of $LEVEL-ERROR, $LEVEL-WARNING, $LEVEL-NOTICE,
     $LEVEL-TEST or $LEVEL-DEBUG.

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2931,9 +2931,9 @@ class InfError extends Message:
   /** See $super. */
   stringify -> string:
     if payload.size > 0:
-      return "$(super.stringify): $text"
+      return "$super: $text"
     else:
-      return "$(super.stringify)"
+      return super
 
 /**
 The UBX-INF-WARNING message.
@@ -2974,9 +2974,9 @@ class InfWarning extends Message:
   /** See $super. */
   stringify -> string:
     if payload.size > 0:
-      return "$(super.stringify): $text"
+      return "$super: $text"
     else:
-      return "$(super.stringify)"
+      return super
 
 /**
 The UBX-INF-NOTICE message.
@@ -3017,9 +3017,9 @@ class InfNotice extends Message:
   /** See $super. */
   stringify -> string:
     if payload.size > 0:
-      return "$(super.stringify): $text"
+      return "$super: $text"
     else:
-      return "$(super.stringify)"
+      return super
 
 /**
 The UBX-INF-TEST message.
@@ -3060,9 +3060,9 @@ class InfTest extends Message:
   /** See $super. */
   stringify -> string:
     if payload.size > 0:
-      return "$(super.stringify): $text"
+      return "$super: $text"
     else:
-      return "$(super.stringify)"
+      return super
 
 /**
 The UBX-INF-DEBUG message.
@@ -3103,6 +3103,6 @@ class InfDebug extends Message:
   /** See $super. */
   stringify -> string:
     if payload.size > 0:
-      return "$(super.stringify): $text"
+      return "$super: $text"
     else:
-      return "$(super.stringify)"
+      return super

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2829,7 +2829,7 @@ class CfgInf extends Message:
     assert: 0 <= raw-value <= 0x1F
 
     if port == PORT-ALL:
-      // Deliberately misses port PORT-RES5, as stipluated in the manual.
+      // Deliberately misses port PORT-RES5, as stipulated in the manual.
       5.repeat:
         put-uint8_ (4 + it) raw-value
     else:

--- a/src/ubx-message.toit
+++ b/src/ubx-message.toit
@@ -2587,7 +2587,7 @@ class CfgGnss extends Message:
   // Flags helpers.
   static FLAG-ENABLE ::= 1
 
-  /** Construct a poll message to retrieve the current GNSS configuration. */
+  /** Constructs a poll message to retrieve the current GNSS configuration. */
   constructor.poll:
     // Empty payload poll (some firmwares accept either empty or msgVer=0).
     super.private_ Message.CFG ID #[]


### PR DESCRIPTION
Ublox has logging levels that work in the same way the logger works.  They arrive as these message types which have been added:
- `UBX-INF-DEBUG`
- `UBX-INF-TEST`
- `UBX-INF-INFO`
- `UBX-INF-WARNING`
- `UBX-INF-NOTICE`
- `UBX-INF-ERROR`

And added an additional message type, which is used to configure which debug message levels are enabled (and via which ports):
- `UBX-CFG-INF`

Other adjustments, alongside:
- Bugfixes for stringify on `UBX-ACK-ACK`, `UBX-ACK-NAK`.
- Bugfix discovered for `UBX-CFG-MSG` which works the same way as `UBX-CFG-INF`.
- Removed `id-string_` from message types as `super.id-string_` is sufficient.

M9+ modules do not accept `UBX-CFG-*` type messages.  VALGET/VALSET/VALDEL message identifiers have been added, but messages will be added to a later release (waiting for test hardware).  After these, "Dynamic Model" and completing a path for local time sync is left, then I will leave it alone, I promise! :)